### PR TITLE
Change tx_rx tty grep to find RaspberryPi attached Arduino

### DIFF
--- a/lib/dino/tx_rx.rb
+++ b/lib/dino/tx_rx.rb
@@ -46,7 +46,7 @@ module Dino
     private
 
     def tty_devices
-      `ls /dev | grep usb`.split(/\n/)
+      `ls /dev`.split("\n").grep(/usb|ACM/)
     end
 
     def find_arduino

--- a/spec/lib/tx_rx_spec.rb
+++ b/spec/lib/tx_rx_spec.rb
@@ -12,9 +12,10 @@ module Dino
 
     describe '#io' do
       it 'should instantiate a new SerialPort for each usb tty device found' do
-        subject.should_receive(:tty_devices).and_return(['cu.usb', 'tty1.usb', 'tty2.usb'])
+        subject.should_receive(:tty_devices).and_return(['cu.usb', 'tty1.usb', 'tty2.usb', 'tty.ACM0'])
         SerialPort.should_receive(:new).with('/dev/tty1.usb', TxRx::BAUD).and_return(mock_serial = mock)
         SerialPort.should_receive(:new).with('/dev/tty2.usb', TxRx::BAUD).and_return(mock)
+        SerialPort.should_receive(:new).with('/dev/tty.ACM0', TxRx::BAUD).and_return(mock)
 
         subject.io.should == mock_serial
       end


### PR DESCRIPTION
The Arduino attaches itself the RaspberryPi as ttyACM0 and this change helps it find that with no hacking of the pi needed
