### PR TITLE
Pass a block instead of a Proc object. Only Button implemented as a matter of principle

### DIFF
--- a/examples/button/button.rb
+++ b/examples/button/button.rb
@@ -9,15 +9,12 @@ require File.expand_path('../../../lib/dino', __FILE__)
 board = Dino::Board.new(Dino::TxRx.new)
 button = Dino::Components::Button.new(pin: 13, board: board)
 
-button_down = Proc.new do
+button.down do
   puts "button down"
 end
 
-button_up = Proc.new do
+button.up do
   puts "button up"
 end
-
-button.down(button_down)
-button.up(button_up)
 
 sleep

--- a/lib/dino/components/button.rb
+++ b/lib/dino/components/button.rb
@@ -11,11 +11,11 @@ module Dino
         self.board.start_read
       end
 
-      def down(callback)
+      def down(&callback)
         @down_callbacks << callback
       end
 
-      def up(callback)
+      def up(&callback)
         @up_callbacks << callback
       end
 

--- a/spec/lib/components/button_spec.rb
+++ b/spec/lib/components/button_spec.rb
@@ -29,52 +29,88 @@ module Dino
         let(:button) {Button.new(board: board, pin: mock)}
         describe '#down' do
           it 'should add a callback to the down_callbacks array' do
-            button.down(callback_mock = mock)
-            button.instance_variable_get(:@down_callbacks).should include callback_mock
+            callback = mock
+            button.down do 
+              callback.called
+            end
+            down_callbacks = button.instance_variable_get(:@down_callbacks)
+            down_callbacks.size.should == 1
+            callback.should_receive(:called)
+            down_callbacks.first.call
           end
         end
 
         describe '#up' do
           it 'should add a callback to the up_callbacks array' do
-            button.up(callback_mock = mock)
-            button.instance_variable_get(:@up_callbacks).should include callback_mock
+            callback = mock
+            button.up do 
+              callback.called
+            end
+            up_callbacks = button.instance_variable_get(:@up_callbacks)
+            up_callbacks.size.should == 1
+            callback.should_receive(:called)
+            up_callbacks.first.call
           end
         end
 
         describe '#update' do
           it 'should call the down callbacks' do
-            button.down(callback_mock1 = mock)
-            button.down(callback_mock2 = mock)
-            callback_mock1.should_receive(:call)
-            callback_mock2.should_receive(:call)
+            callback_1 = mock
+            button.down do 
+              callback_1.called
+            end
+            
+            callback_2 = mock
+            button.down do 
+              callback_2.called
+            end
+            callback_1.should_receive(:called)
+            callback_2.should_receive(:called)
             button.update(Button::DOWN)
           end
 
           it 'should call the up callbacks' do
-            button.up(callback_mock1 = mock)
-            button.up(callback_mock2 = mock)
+            callback_1 = mock
+            button.up do 
+              callback_1.called
+            end
+            
+            callback_2 = mock
+            button.up do 
+              callback_2.called
+            end
 
             button.instance_variable_set(:@state, Button::DOWN)
 
-            callback_mock1.should_receive(:call)
-            callback_mock2.should_receive(:call)
+            callback_1.should_receive(:called)
+            callback_2.should_receive(:called)
             button.update(Button::UP)
           end
 
           it 'should not call the callbacks if the state has not changed' do
-            button.up(callback_mock = mock)
+            callback = mock
+            button.up do
+              callback.called
+            end
 
-            callback_mock.should_not_receive(:call)
+            callback.should_not_receive(:called)
             button.update(Button::UP)
             button.update(Button::UP)
           end
 
           it 'should not call the callbacks if the data is not UP or DOWN' do
-            button.up(callback_mock1 = mock)
-            button.down(callback_mock2 = mock)
+            callback_1 = mock
+            button.up do 
+              callback_1.called
+            end
 
-            callback_mock1.should_not_receive(:call)
-            callback_mock2.should_not_receive(:call)
+            callback_2 = mock
+            button.down do 
+              callback_2.called
+            end
+
+            callback_1.should_not_receive(:called)
+            callback_2.should_not_receive(:called)
             button.update('foobarred')
           end
         end


### PR DESCRIPTION
I prefer this:

<pre>
button.down do
  puts "button down"
end

button.up do
  puts "button up"
end
</pre>


instead of:

<pre>
button_down = Proc.new do
  puts "button down"
end

button_up = Proc.new do
  puts "button up"
end

button.down do
  button_down
end

button.up do
  button_up
end
</pre>


Issue: backward compatibility
