### PR TITLE
Fixing defined constant error in usb_serial_spec

### DIFF
--- a/spec/lib/tx_rx/usb_serial_spec.rb
+++ b/spec/lib/tx_rx/usb_serial_spec.rb
@@ -14,7 +14,7 @@ module Dino
       context "on windows" do
         it 'should instantiate a new SerialPort for each usb tty device found' do
           original_platform = RUBY_PLATFORM
-          RUBY_PLATFORM = "mswin"
+          Constants.redefine(:RUBY_PLATFORM, "mswin", :on => Object)
           subject.should_receive(:tty_devices).and_return(["COM1", "COM2", "COM3", "COM4"])
           SerialPort.should_receive(:new).with('COM1', TxRx::USBSerial::BAUD).and_return(mock_serial = mock)
           SerialPort.should_receive(:new).with('COM2', TxRx::USBSerial::BAUD).and_return(mock)
@@ -22,7 +22,7 @@ module Dino
           SerialPort.should_receive(:new).with('COM4', TxRx::USBSerial::BAUD).and_return(mock)
 
           subject.io.should == mock_serial
-          RUBY_PLATFORM = original_platform
+          Constants.redefine(:RUBY_PLATFORM, original_platform, :on => Object)
         end
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,12 @@
 require 'rspec'
 
 require File.expand_path(File.join('../..', 'lib/dino'), __FILE__)
+
+# Nice little helper module to redefine constants quietly.
+module Constants
+  def self.redefine(const, value, opts={})
+    opts = {:on => self.class}.merge(opts)
+    opts[:on].send(:remove_const, const) if self.class.const_defined?(const)
+    opts[:on].const_set(const, value)
+  end
+end


### PR DESCRIPTION
This is an issue that pops up a lot in tests, luckily easily fixed :smile:
