### PR TITLE
serial ports for linux

### DIFF
--- a/lib/dino/tx_rx/usb_serial.rb
+++ b/lib/dino/tx_rx/usb_serial.rb
@@ -54,7 +54,7 @@ module Dino
           1.upto(9) { |n| com_ports << "COM#{n}" }
           com_ports
         else
-          `ls /dev`.split("\n").grep(/usb|ACM/).map{|d| "/dev/#{d}"}
+          `ls /dev`.split("\n").grep(/usb|ACM/i).map{|d| "/dev/#{d}"}
         end
       end
 


### PR DESCRIPTION
Detect Serial Ports from Linux.

Alternate way is to execture

`dmesg | grep tty`

But the output cannot be easily parsed.

So followed the way windows COM ports are done.
