### PR TITLE
failing attempt to bring SoftwareSerial to dino

### DIFF
--- a/src/dino_serial.ino
+++ b/src/dino_serial.ino
@@ -1,6 +1,7 @@
 #include "Dino.h"
 #include <Servo.h>
 #include <LiquidCrystal.h>
+#include <SoftwareSerial.h>
 Dino dino;
 
 // Use the native serial port on the Arduino Due

--- a/src/lib/Dino.cpp
+++ b/src/lib/Dino.cpp
@@ -5,6 +5,7 @@
 #include "Arduino.h"
 #include "Dino.h"
 DinoLCD dinoLCD;
+DinoSerial dinoSerial;
 
 Dino::Dino(){
   messageFragments[0] = cmdStr;
@@ -79,6 +80,7 @@ void Dino::process() {
     case 9:  servoWrite          ();  break;
     case 10: handleLCD           ();  break;
     case 11: shiftWrite          ();  break;
+    case 12: handleSerial        ();  break;
     case 90: reset               ();  break;
     case 96: setAnalogResolution ();  break;
     case 97: setAnalogDivider    ();  break;
@@ -272,6 +274,15 @@ void Dino::shiftWrite() {
   #endif
   // auxMsg should be the clock pin.
   shiftOut(pin, atoi(auxMsg), MSBFIRST, val);
+}
+
+// CMD = 12
+// Write a value to the servo object.
+void Dino::handleSerial() {
+  #ifdef debug
+    Serial.print("DinoSerial command: "); Serial.print(val); Serial.print(" with data: "); Serial.println(auxMsg);
+  #endif
+  dinoSerial.process(val, auxMsg);
 }
 
 // CMD = 90

--- a/src/lib/Dino.h
+++ b/src/lib/Dino.h
@@ -8,6 +8,7 @@
 #include "Arduino.h"
 #include <Servo.h>
 #include "DinoLCD.h"
+#include "DinoSerial.h"
 
 // Allocate listener storage based on what board we're running.
 #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
@@ -45,6 +46,7 @@ class Dino {
     void servoWrite            ();  //cmd = 9
     void handleLCD             ();  //cmd = 10
     void shiftWrite            ();  //cmd = 11
+    void handleSerial          ();  //cmd = 12
     void reset                 ();  //cmd = 90
     void setAnalogResolution   ();  //cmd = 96
     void setAnalogDivider      ();  //cmd = 97

--- a/src/lib/DinoSerial.cpp
+++ b/src/lib/DinoSerial.cpp
@@ -1,0 +1,40 @@
+#include "Arduino.h"
+#include "DinoSerial.h"
+
+SoftwareSerial serial(10,11);
+
+DinoSerial::DinoSerial(){
+}
+
+int *DinoSerial::parse(char *aux){
+  int *values = new int[11];
+  char *str;
+  int index = 0;
+  while ((str = strsep(&aux, ",")) != NULL) {
+    values[index] = atoi(str);
+    index++;
+  }
+  parseSize = index;
+  return values;
+}
+
+void DinoSerial::process(int cmd, char *message) {
+  switch(cmd) {
+    case 0:  setPins(message);           break;
+    case 1:  beginSerial(message);       break;
+    default:                             break;
+  }
+}
+
+void DinoSerial::setPins(char *aux) {
+  int *pins = parse(aux);
+  SoftwareSerial newSerial(pins[0],pins[1]);
+  serial = newSerial;
+
+}
+
+void DinoSerial::beginSerial(char *aux) {
+  int *values = parse(aux);
+  // set baud rate
+  serial.begin(values[0]);
+}

--- a/src/lib/DinoSerial.h
+++ b/src/lib/DinoSerial.h
@@ -1,0 +1,18 @@
+#ifndef DinoSerial_h
+#define DinoSerial_h
+
+#include "Arduino.h"
+#include <SoftwareSerial.h>
+
+class DinoSerial {
+  public:
+    DinoSerial();
+    void process(int cmd, char *message);
+  private:
+    int *parse(char *aux);
+    void setPins(char *aux);
+    void beginSerial(char *aux);
+    int parseSize;
+};
+
+#endif


### PR DESCRIPTION
I'm trying to bring SoftwareSerial support to Dino (to eventually support the AdaFruit Thermal printer). I have a pretty good handle on what is going on on the ruby side of the code, and I think I have structured this addition in the proper way. However, it won't compile, for what I imagine is just a basic C++ issue I don't understand. I'm including the code, but the error occurs when trying to reassign the serial object to a new one once setPins is called. 

```
DinoSerial.cpp.o:(.bss.serial+0x0): multiple definition of `serial'
dino_serial.cpp.o:(.bss.serial+0x0): first defined here
/Users/cdcarter/Downloads/Arduino.app/Contents/Resources/Java/hardware/tools/avr/bin/../lib/gcc/avr/4.3.2/../../../../avr/bin/ld: Warning: size of symbol `serial' changed from 34 in dino_serial.cpp.o to 28 in DinoSerial.cpp.o
```

I realize a pull request isn't the best way to get this on someones radar, but I'd love to try and figure out how to get basic SoftwareSerial support into the Arduino half of the equation, and I'm happy to hack away on the ruby side to get communication flowing both ways and a printer connected!

Email or Twitter for conversation!
