### PR TITLE
Added value attribute to Sensor to allow for analog read

### DIFF
--- a/lib/dino/components/sensor.rb
+++ b/lib/dino/components/sensor.rb
@@ -1,8 +1,11 @@
 module Dino
   module Components
     class Sensor < BaseComponent
+      attr_reader :value
+
       def after_initialize(options={})
         @data_callbacks = []
+        @value = 0
         @board.add_analog_hardware(self)
         @board.start_read
       end
@@ -12,6 +15,7 @@ module Dino
       end
 
       def update(data)
+        @value = data
         @data_callbacks.each do |callback|
           callback.call(data)
         end

--- a/spec/lib/components/sensor_spec.rb
+++ b/spec/lib/components/sensor_spec.rb
@@ -29,10 +29,15 @@ module Dino
           sensor = Sensor.new(board: board, pin: 'a pin')
           sensor.instance_variable_get(:@data_callbacks).should == []
         end
+
+        it 'should initialize value' do
+          sensor = Sensor.new(board: board, pin: 'a pin')
+          sensor.value.should == 0
+        end
       end
 
       describe '#when_data_received' do
-        
+
         it "should add a callback to the list of callbacks" do
           sensor = Sensor.new(board: board, pin: 'a pin')
           sensor.when_data_received { "this is a block" }
@@ -43,7 +48,7 @@ module Dino
       describe '#update' do
         it 'should call all callbacks passing in the given data' do
           sensor = Sensor.new(board: board, pin: 'a pin')
-          
+
           first_block_data = nil
           second_block_data = nil
           sensor.when_data_received do |data|
@@ -55,6 +60,13 @@ module Dino
 
           sensor.update('Some data')
           [first_block_data, second_block_data].each { |block_data| block_data.should == "Some data" }
+        end
+
+        it 'should update the value' do
+          sensor = Sensor.new(board: board, pin: 'a pin')
+
+          sensor.update('Some data')
+          sensor.value.should == 'Some data'
         end
       end
     end


### PR DESCRIPTION
This would let you call `.value` on a `Dino::Components::Sensor` object and get the analog value at any time.
