### PR TITLE
Silence deprecation warnings for rspec 2.14.x

### DIFF
--- a/spec/lib/board_spec.rb
+++ b/spec/lib/board_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 module Dino
   describe Dino::Board do
     def io_mock(methods = {})
-      @io ||= mock(:io, {write: nil, add_observer: nil, flush_read: nil, handshake: "14"}.merge(methods))
+      @io ||= double(:io, {write: nil, add_observer: nil, flush_read: nil, handshake: "14"}.merge(methods))
     end
 
     subject { Board.new(io_mock) }
@@ -29,9 +29,9 @@ module Dino
     describe '#update' do
       context 'when the given pin connects to an analog hardware part' do
         it 'should call update with the message on the part' do
-          part = mock(:part, pin: 7)
+          part = double(:part, pin: 7)
           subject.add_analog_hardware(part)
-          other_part = mock(:part, pin: 9)
+          other_part = double(:part, pin: 9)
           subject.add_analog_hardware(other_part)
 
           part.should_receive(:update).with('wake up!')
@@ -41,9 +41,9 @@ module Dino
 
       context 'when the given pin connects to an digital hardware part' do
         it 'should call update with the message on the part' do
-          part = mock(:part, pin: 5, pullup: nil)
+          part = double(:part, pin: 5, pullup: nil)
           subject.add_digital_hardware(part)
-          other_part = mock(:part, pin: 11, pullup: nil)
+          other_part = double(:part, pin: 11, pullup: nil)
           subject.add_digital_hardware(other_part)
 
           part.should_receive(:update).with('wake up!')
@@ -76,8 +76,8 @@ module Dino
 
     describe '#add_digital_hardware' do
       it 'should add digital hardware to the board' do
-        subject.add_digital_hardware(mock1 = mock(:part1, pin: 12, pullup: nil))
-        subject.add_digital_hardware(mock2 = mock(:part2, pin: 14, pullup: nil))
+        subject.add_digital_hardware(mock1 = double(:part1, pin: 12, pullup: nil))
+        subject.add_digital_hardware(mock2 = double(:part2, pin: 14, pullup: nil))
         subject.digital_hardware.should =~ [mock1, mock2]
       end
 
@@ -86,23 +86,23 @@ module Dino
         subject.should_receive(:write).with("0012001")
         subject.should_receive(:write).with("0112000")
         subject.should_receive(:write).with("0512000")
-        subject.add_digital_hardware(mock1 = mock(:part1, pin: 12, pullup: nil))
+        subject.add_digital_hardware(mock1 = double(:part1, pin: 12, pullup: nil))
       end
     end
 
     describe '#remove_digital_hardware' do
       it 'should remove the given part from the hardware of the board' do
-        mock = mock(:part1, pin: 12, pullup: nil)
-        subject.add_digital_hardware(mock)
-        subject.remove_digital_hardware(mock)
+        double = double(:part1, pin: 12, pullup: nil)
+        subject.add_digital_hardware(double)
+        subject.remove_digital_hardware(double)
         subject.digital_hardware.should == []
       end
     end
 
     describe '#add_analog_hardware' do
       it 'should add analog hardware to the board' do
-        subject.add_analog_hardware(mock1 = mock(:part1, pin: 12, pullup: nil))
-        subject.add_analog_hardware(mock2 = mock(:part2, pin: 14, pullup: nil))
+        subject.add_analog_hardware(mock1 = double(:part1, pin: 12, pullup: nil))
+        subject.add_analog_hardware(mock2 = double(:part2, pin: 14, pullup: nil))
         subject.analog_hardware.should =~ [mock1, mock2]
       end
 
@@ -111,15 +111,15 @@ module Dino
         subject.should_receive(:write).with("0012001")
         subject.should_receive(:write).with("0112000")
         subject.should_receive(:write).with("0612000")
-        subject.add_analog_hardware(mock1 = mock(:part1, pin: 12, pullup: nil))
+        subject.add_analog_hardware(mock1 = double(:part1, pin: 12, pullup: nil))
       end
     end
 
     describe '#remove_analog_hardware' do
       it 'should remove the given part from the hardware of the board' do
-        mock = mock(:part1, pin: 12, pullup: nil)
-        subject.add_analog_hardware(mock)
-        subject.remove_analog_hardware(mock)
+        double = double(:part1, pin: 12, pullup: nil)
+        subject.add_analog_hardware(double)
+        subject.remove_analog_hardware(double)
         subject.analog_hardware.should == []
       end
     end

--- a/spec/lib/components/button_spec.rb
+++ b/spec/lib/components/button_spec.rb
@@ -17,7 +17,7 @@ module Dino
         end
 
         it 'should add itself to the board and start reading' do
-          board = mock(:board)
+          board = double(:board)
           board.should_receive(:add_digital_hardware)
           board.should_receive(:start_read)
           Button.new(board: board, pin: 'a pin')
@@ -25,11 +25,11 @@ module Dino
       end
 
       context 'callbacks' do
-        let(:board) { mock(:board, add_digital_hardware: true, start_read: true) }
-        let(:button) {Button.new(board: board, pin: mock)}
+        let(:board) { double(:board, add_digital_hardware: true, start_read: true) }
+        let(:button) {Button.new(board: board, pin: double)}
         describe '#down' do
           it 'should add a callback to the down_callbacks array' do
-            callback = mock
+            callback = double
             button.down do 
               callback.called
             end
@@ -42,7 +42,7 @@ module Dino
 
         describe '#up' do
           it 'should add a callback to the up_callbacks array' do
-            callback = mock
+            callback = double
             button.up do 
               callback.called
             end
@@ -55,12 +55,12 @@ module Dino
 
         describe '#update' do
           it 'should call the down callbacks' do
-            callback_1 = mock
+            callback_1 = double
             button.down do 
               callback_1.called
             end
             
-            callback_2 = mock
+            callback_2 = double
             button.down do 
               callback_2.called
             end
@@ -70,12 +70,12 @@ module Dino
           end
 
           it 'should call the up callbacks' do
-            callback_1 = mock
+            callback_1 = double
             button.up do 
               callback_1.called
             end
             
-            callback_2 = mock
+            callback_2 = double
             button.up do 
               callback_2.called
             end
@@ -88,7 +88,7 @@ module Dino
           end
 
           it 'should not call the callbacks if the state has not changed' do
-            callback = mock
+            callback = double
             button.up do
               callback.called
             end
@@ -99,12 +99,12 @@ module Dino
           end
 
           it 'should not call the callbacks if the data is not UP or DOWN' do
-            callback_1 = mock
+            callback_1 = double
             button.up do 
               callback_1.called
             end
 
-            callback_2 = mock
+            callback_2 = double
             button.down do 
               callback_2.called
             end

--- a/spec/lib/components/led_spec.rb
+++ b/spec/lib/components/led_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 module Dino
   module Components
     describe Led do
-      let(:board) { mock(:board, digital_write: true, set_pin_mode: true) }
+      let(:board) { double(:board, digital_write: true, set_pin_mode: true) }
 
       describe '#initialize' do
         it 'should raise if it does not receive a pin' do

--- a/spec/lib/components/rgb_led_spec.rb
+++ b/spec/lib/components/rgb_led_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 module Dino
   module Components
     describe RgbLed do
-      let(:board) { mock(:board, analog_write: true, set_pin_mode: true) }
+      let(:board) { double(:board, analog_write: true, set_pin_mode: true) }
       let(:pins) { {red: 1, green: 2, blue: 3} }
       let(:rgb) { RgbLed.new(pins: pins, board: board)}
 

--- a/spec/lib/components/sensor_spec.rb
+++ b/spec/lib/components/sensor_spec.rb
@@ -4,7 +4,7 @@ module Dino
   module Components
     describe Sensor do
 
-      let(:board){mock(:board).as_null_object}
+      let(:board){double(:board).as_null_object}
 
       describe '#initalize' do
         it 'should raise if it does not receive a pin' do

--- a/spec/lib/components/servo_spec.rb
+++ b/spec/lib/components/servo_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 module Dino
   module Components
     describe Servo do
-      let(:board) { mock(:board, analog_write: true, set_pin_mode: true, servo_toggle: true, servo_write: true) }
+      let(:board) { double(:board, analog_write: true, set_pin_mode: true, servo_toggle: true, servo_write: true) }
 
       describe '#initialize' do
         it 'should raise if it does not receive a pin' do

--- a/spec/lib/components/stepper_spec.rb
+++ b/spec/lib/components/stepper_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 module Dino
   module Components
     describe Stepper do
-      let(:board) { mock(:board, digital_write: true, set_pin_mode: true) }
+      let(:board) { double(:board, digital_write: true, set_pin_mode: true) }
 
       describe '#initialize' do
         it 'should raise if it does not receive a step pin' do

--- a/spec/lib/tx_rx/serial_spec.rb
+++ b/spec/lib/tx_rx/serial_spec.rb
@@ -25,7 +25,7 @@ module Dino
 
           # COM2 is chosen as available for this test.
           SerialPort.should_receive(:new).with("COM1", TxRx::Serial::BAUD).and_raise
-          SerialPort.should_receive(:new).with("COM2", TxRx::Serial::BAUD).and_return(mock_serial = mock)
+          SerialPort.should_receive(:new).with("COM2", TxRx::Serial::BAUD).and_return(mock_serial = double)
           SerialPort.should_not_receive(:new).with("COM3", TxRx::Serial::BAUD)
 
           subject.io.should == mock_serial
@@ -38,7 +38,7 @@ module Dino
           subject.should_receive(:tty_devices).and_return(['/dev/ttyACM0', '/dev/tty.usbmodem1'])
 
           # /dev/ttyACM0 is chosen as available for this test.
-          SerialPort.should_receive(:new).with('/dev/ttyACM0', TxRx::Serial::BAUD).and_return(mock_serial = mock)
+          SerialPort.should_receive(:new).with('/dev/ttyACM0', TxRx::Serial::BAUD).and_return(mock_serial = double)
           SerialPort.should_not_receive(:new).with('/dev/tty.usbmodem1', TxRx::Serial::BAUD)
 
           subject.io.should == mock_serial
@@ -47,7 +47,7 @@ module Dino
 
       it 'should connect to the specified device at the specified baud rate' do
         subject.should_receive(:tty_devices).and_return(["/dev/ttyACM0"])
-        SerialPort.should_receive(:new).with('/dev/ttyACM0', 9600).and_return(mock_serial = mock)
+        SerialPort.should_receive(:new).with('/dev/ttyACM0', 9600).and_return(mock_serial = double)
 
         subject.instance_variable_set(:@device, "/dev/ttyACM0")
         subject.instance_variable_set(:@baud, 9600)
@@ -57,7 +57,7 @@ module Dino
 
       it 'should use the existing io instance if set' do
         subject.should_receive(:tty_devices).once.and_return(['/dev/tty.ACM0', '/dev/tty.usbmodem1'])
-        SerialPort.stub(:new).and_return(mock_serial = mock)
+        SerialPort.stub(:new).and_return(mock_serial = double)
 
         3.times { subject.io }
         subject.io.should == mock_serial
@@ -76,7 +76,7 @@ module Dino
       end
 
       it 'should get messages from the device' do
-        subject.stub(:io).and_return(mock_serial = mock)
+        subject.stub(:io).and_return(mock_serial = double)
 
         IO.should_receive(:select).and_return(true)
         Thread.should_receive(:new).and_yield
@@ -91,7 +91,7 @@ module Dino
 
     describe '#close_read' do
       it 'should kill the reading thread' do
-        subject.instance_variable_set(:@thread, mock_thread = mock)
+        subject.instance_variable_set(:@thread, mock_thread = double)
         Thread.should_receive(:kill).with(mock_thread)
         subject.read
         subject.close_read
@@ -102,7 +102,7 @@ module Dino
       it 'should write to the device' do
         IO.should_receive(:select).and_return(true)
 
-        subject.stub(:io).and_return(mock_serial = mock)
+        subject.stub(:io).and_return(mock_serial = double)
         mock_serial.should_receive(:syswrite).with('a message')
         subject.write('a message')
       end


### PR DESCRIPTION
Since Gemspec doesn't specify an rspec version I got the latest. This pull request silences the deprecation warnings for that version.
