### PR TITLE
fixed bug Dino::TxRx::Base#gets on Windows 8.1/ruby 2.0.0p353

### DIFF
--- a/lib/dino/tx_rx/base.rb
+++ b/lib/dino/tx_rx/base.rb
@@ -1,5 +1,4 @@
 require 'observer'
-require 'timeout'
 
 module Dino
   module TxRx
@@ -51,7 +50,14 @@ module Dino
       end
 
       def gets(timeout=0.005)
-        IO.select([io], nil, nil, timeout) && io.gets
+        return nil unless IO.select([io], nil, nil, timeout)
+        io.read_timeout = (timeout * 1000).to_i
+        bytes = []
+        until (x = io.getbyte).nil?
+          bytes.push(x)
+        end
+        return nil if bytes.empty?
+        bytes.pack("C*")
       end
     end
   end


### PR DESCRIPTION
SerialPort#gets does not work on Windows 8.1/ruby 2.0.0p353. So I
modified using SerialPort#read_timeout and SerialPort#getbyte in
Dino::TxRx::Base#gets.