### PR TITLE
Print usage info on run without params

### DIFF
--- a/bin/dino
+++ b/bin/dino
@@ -31,7 +31,7 @@ def usage
 end
 
 # Command must be the first argument.
-$options[:command] = ARGV.shift
+$options[:command] = ARGV.shift || 'help'
 usage if $options[:command].match /help/
 
 # Parse the rest loosely.


### PR DESCRIPTION
Running dino without any params ends up in error:

```
$ ./bin/dino
./bin/dino:35:in `<main>': undefined method `match' for nil:NilClass (NoMethodError)
Did you mean?  catch
```

With this patch it will end up printing usage information.
